### PR TITLE
[Feature] 관심상품에 대한 요청 시 token에서 member uuid를 추출해서 사용하도록 수정

### DIFF
--- a/src/main/java/colorful/starbucks/product/infrastructure/ProductDetailRepository.java
+++ b/src/main/java/colorful/starbucks/product/infrastructure/ProductDetailRepository.java
@@ -17,4 +17,7 @@ public interface ProductDetailRepository extends JpaRepository<ProductDetail, Lo
             String productCode, Long sizeId, Long colorId
     );
 
+    @Query(value = "select pd from ProductDetail pd " +
+            "where pd.productDetailCode = :productDetailCode and pd.isDeleted = false")
+    Optional<ProductDetail> findByProductDetailCode(String productDetailCode);
 }

--- a/src/main/java/colorful/starbucks/product/presentation/InterestProductController.java
+++ b/src/main/java/colorful/starbucks/product/presentation/InterestProductController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -19,35 +20,34 @@ public class InterestProductController {
 
     private final InterestProductService interestProductService;
 
-    @GetMapping("/{memberUuid}")
-    public ApiResponse<InterestProductListResponseVo> getInterestProducts(@PathVariable String memberUuid,
+    @GetMapping
+    public ApiResponse<InterestProductListResponseVo> getInterestProducts(Authentication authentication,
                                                                           @PageableDefault(size = 3) Pageable pageable) {
         return ApiResponse.of(HttpStatus.OK,
                 "관심 상품 조회를 완료했습니다.",
-                interestProductService.getInterestProductList(memberUuid, pageable).toVo()
+                interestProductService.getInterestProductList(authentication.getName(), pageable).toVo()
         );
     }
 
-    // todo: security 완료되면 memberUuid는 authentication에서 가져오도록 수정
-    @PostMapping("/{memberUuid}")
+    @PostMapping
     public ApiResponse<InterestProductCreateResponseVo> createInterestProduct(
             @RequestBody InterestProductCreateRequestVo interestProductCreateRequestVo,
-            @PathVariable String memberUuid) {
+            Authentication authentication) {
 
         return ApiResponse.of(
                 HttpStatus.CREATED,
                 "관심 상품 등록을 완료했습니다." ,
                 interestProductService.createInterestProduct(
-                                InterestProductCreateRequestDto.from(interestProductCreateRequestVo, memberUuid))
+                                InterestProductCreateRequestDto.from(interestProductCreateRequestVo, authentication.getName()))
                         .toVo()
         );
     }
 
-    @DeleteMapping("/{memberUuid}/{productCode}")
-    public ApiResponse<Void> removeInterestProduct(@PathVariable String memberUuid,
+    @DeleteMapping("/{productCode}")
+    public ApiResponse<Void> removeInterestProduct(Authentication authentication,
                                                    @PathVariable String productCode) {
 
-        interestProductService.removeInterestProduct(memberUuid, productCode);
+        interestProductService.removeInterestProduct(authentication.getName(), productCode);
         return ApiResponse.of(HttpStatus.NO_CONTENT, "관심 상품 삭제를 완료했습니다.", null);
     }
 }

--- a/src/main/java/colorful/starbucks/product/presentation/InterestProductController.java
+++ b/src/main/java/colorful/starbucks/product/presentation/InterestProductController.java
@@ -36,7 +36,7 @@ public class InterestProductController {
 
         return ApiResponse.of(
                 HttpStatus.CREATED,
-                "관심 상품 등록을 완료했습니다." ,
+                "관심 상품 등록을 완료했습니다.",
                 interestProductService.createInterestProduct(
                                 InterestProductCreateRequestDto.from(interestProductCreateRequestVo, authentication.getName()))
                         .toVo()


### PR DESCRIPTION
## #️⃣연관된 이슈

> #49 

## 📝작업 내용
컨트롤러에서 authentication 객체 주입받아 member uuid 추출해서 사용

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/ef7f092f-0f1d-43e9-b813-7f9d1c86852e)

api 요청 주소에 memberUuid가 제거된 것을 확인할 수 있습니다.