### PR TITLE
[Fix] 장바구니 선택 개별로 변경

### DIFF
--- a/src/main/java/colorful/starbucks/cart/application/CartService.java
+++ b/src/main/java/colorful/starbucks/cart/application/CartService.java
@@ -14,6 +14,6 @@ public interface CartService {
     CartListResponseDto getCartList(String memberUuid, Pageable pageable);
     void editCartOptions(CartOptionEditRequestDto cartOptionEditRequestDto);
     CartDetailResponseDto getCartDetail(Long cartId);
-    void updateCartChecked(List<CartCheckRequestDto> cartCheckRequestDtos);
+    void updateCartChecked(CartCheckRequestDto cartCheckRequestDto);
     void removeAllCart(String memberUuid);
 }

--- a/src/main/java/colorful/starbucks/cart/application/CartServiceImpl.java
+++ b/src/main/java/colorful/starbucks/cart/application/CartServiceImpl.java
@@ -53,15 +53,12 @@ public class CartServiceImpl implements CartService {
 
     @Transactional
     @Override
-    public void updateCartChecked(List<CartCheckRequestDto> cartCheckRequestDtos) {
+    public void updateCartChecked(CartCheckRequestDto cartCheckRequestDto) {
 
-        cartCheckRequestDtos
-                .forEach(c -> {
-                    cartRepository.findByIdAndMemberUuid(c.getId(), c.getMemberUuid())
-                            .orElseThrow(() -> new BaseException(ResponseStatus.RESOURCE_NOT_FOUND))
-                            .updateProductChecked(c.isChecked());
+        cartRepository.findByIdAndMemberUuid(cartCheckRequestDto.getId(), cartCheckRequestDto.getMemberUuid())
+                .orElseThrow(() -> new BaseException(ResponseStatus.RESOURCE_NOT_FOUND))
+                .updateProductChecked(cartCheckRequestDto.isChecked());
 
-                });
     }
 
     @Override

--- a/src/main/java/colorful/starbucks/cart/dto/request/CartCheckRequestDto.java
+++ b/src/main/java/colorful/starbucks/cart/dto/request/CartCheckRequestDto.java
@@ -21,16 +21,12 @@ public class CartCheckRequestDto {
         this.memberUuid = memberUuid;
     }
 
-    private static CartCheckRequestDto of(CartCheckRequestVo cartCheckRequestVo, String memberUuid) {
+    public static CartCheckRequestDto of(CartCheckRequestVo cartCheckRequestVo, String memberUuid) {
         return CartCheckRequestDto.builder()
                 .id(cartCheckRequestVo.getId())
                 .checked(cartCheckRequestVo.isChecked())
                 .memberUuid(memberUuid)
                 .build();
     }
-    public static List<CartCheckRequestDto> of(List<CartCheckRequestVo> cartCheckRequestVos, String memberUuid) {
-        return cartCheckRequestVos.stream()
-                .map(vo -> of(vo, memberUuid))
-                .collect(Collectors.toList());
-    }
+
 }

--- a/src/main/java/colorful/starbucks/cart/presentation/CartController.java
+++ b/src/main/java/colorful/starbucks/cart/presentation/CartController.java
@@ -47,10 +47,10 @@ public class CartController {
     }
 
     @PutMapping("/checked")
-    public ApiResponse<CartCheckRequestVo> updateCartProductCheck(Authentication authentication,
-                                                                  @RequestBody List<CartCheckRequestVo> cartCheckRequestVos) {
+    public ApiResponse<Void> updateCartProductCheck(Authentication authentication,
+                                                                  @RequestBody CartCheckRequestVo cartCheckRequestVo) {
 
-        cartService.updateCartChecked(CartCheckRequestDto.of(cartCheckRequestVos, authentication.getName()));
+        cartService.updateCartChecked(CartCheckRequestDto.of(cartCheckRequestVo, authentication.getName()));
         return ApiResponse.ok("장바구니 상품의 체크 여부를 변경했습니다.",
                 null);
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #93

## 📝작업 내용

> 프론트의 요청으로 장바구니 목록에 있는 상품 선택 유무를 리스트가 아닌 목록 하나씩 보내는 것으로 변경했습니다.

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/f934c27b-7608-46b7-9689-b977c0a3e8ae)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
