### PR TITLE
[Refactor] 쿠폰 더티체킹 제거 및 AOP 적용 순서 조정

### DIFF
--- a/src/main/java/colorful/starbucks/common/aop/AopForTransaction.java
+++ b/src/main/java/colorful/starbucks/common/aop/AopForTransaction.java
@@ -8,7 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 public class AopForTransaction {
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW, timeout = 2)
+    @Transactional(propagation = Propagation.REQUIRES_NEW, timeout = 4)
     public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
             return joinPoint.proceed();
     }

--- a/src/main/java/colorful/starbucks/common/aop/DistributedLock.java
+++ b/src/main/java/colorful/starbucks/common/aop/DistributedLock.java
@@ -30,5 +30,5 @@ public @interface DistributedLock {
      * 락 임대 시간 (default - 3s)
      * 락을 획득한 후 leaseTime 이 지나면 락을 해제한다.
      */
-    long leaseTime() default 3L;
+    long leaseTime() default 5L;
 }

--- a/src/main/java/colorful/starbucks/common/aop/DistributedLockAop.java
+++ b/src/main/java/colorful/starbucks/common/aop/DistributedLockAop.java
@@ -8,6 +8,7 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 import java.lang.reflect.Method;
@@ -16,6 +17,7 @@ import java.lang.reflect.Method;
 @Component
 @RequiredArgsConstructor
 @Slf4j
+@Order(1)
 public class DistributedLockAop {
 
     private static final String REDISSON_LOCK_PREFIX = "LOCK:";

--- a/src/main/java/colorful/starbucks/coupon/application/CouponService.java
+++ b/src/main/java/colorful/starbucks/coupon/application/CouponService.java
@@ -8,5 +8,7 @@ public interface CouponService {
 
     Coupon createCoupon(CouponCreateRequestDto couponCreateRequestDto);
 
+    void issueCoupon(String couponUuid);
+
     CouponResponseDto getCoupon(String couponUuid);
 }

--- a/src/main/java/colorful/starbucks/coupon/application/EventCouponMappingServiceImpl.java
+++ b/src/main/java/colorful/starbucks/coupon/application/EventCouponMappingServiceImpl.java
@@ -27,8 +27,6 @@ public class EventCouponMappingServiceImpl implements EventCouponMappingService 
             eventCouponMappingRepository.save(eventCouponMappingCreateRequestDto.toEntity());
         } catch (DataIntegrityViolationException e) {
             throw new BaseException(ResponseStatus.CONFLICT_REQUEST);
-        } catch (Exception e) {
-            throw new BaseException(ResponseStatus.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/main/java/colorful/starbucks/coupon/application/EventCouponMappingServiceImpl.java
+++ b/src/main/java/colorful/starbucks/coupon/application/EventCouponMappingServiceImpl.java
@@ -1,13 +1,10 @@
 package colorful.starbucks.coupon.application;
 
-import colorful.starbucks.common.exception.BaseException;
-import colorful.starbucks.common.response.ResponseStatus;
 import colorful.starbucks.coupon.dto.request.EventCouponMappingCreateRequestDto;
 import colorful.starbucks.coupon.dto.request.EventCouponUuidRequestDto;
 import colorful.starbucks.coupon.dto.response.EventCouponUuidResponseDto;
 import colorful.starbucks.coupon.infrastructure.EventCouponMappingRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,12 +19,7 @@ public class EventCouponMappingServiceImpl implements EventCouponMappingService 
     @Transactional
     @Override
     public void createEventCouponMapping(EventCouponMappingCreateRequestDto eventCouponMappingCreateRequestDto) {
-
-        try {
-            eventCouponMappingRepository.save(eventCouponMappingCreateRequestDto.toEntity());
-        } catch (DataIntegrityViolationException e) {
-            throw new BaseException(ResponseStatus.CONFLICT_REQUEST);
-        }
+        eventCouponMappingRepository.save(eventCouponMappingCreateRequestDto.toEntity());
     }
 
     @Override

--- a/src/main/java/colorful/starbucks/coupon/application/MemberCouponService.java
+++ b/src/main/java/colorful/starbucks/coupon/application/MemberCouponService.java
@@ -5,9 +5,13 @@ import colorful.starbucks.coupon.dto.request.MemberCouponCreateRequestDto;
 import colorful.starbucks.coupon.dto.request.MemberCouponRequestDto;
 import colorful.starbucks.coupon.dto.response.MemberCouponResponseDto;
 
+import java.time.LocalDateTime;
+
 public interface MemberCouponService {
 
     void createMemberCoupon(MemberCouponCreateRequestDto memberCouponCreateRequestDto);
 
     CursorPage<MemberCouponResponseDto> getMemberCoupons(MemberCouponRequestDto memberCouponRequestDto);
+
+    void useCoupon(String couponUuid, String memberUuid, LocalDateTime usedAt);
 }

--- a/src/main/java/colorful/starbucks/coupon/application/MemberCouponServiceImpl.java
+++ b/src/main/java/colorful/starbucks/coupon/application/MemberCouponServiceImpl.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -29,6 +31,12 @@ public class MemberCouponServiceImpl implements MemberCouponService {
         couponService.issueCoupon(memberCouponCreateRequestDto.getCouponUuid());
 
         memberCouponRepository.save(memberCouponCreateRequestDto.toEntity());
+    }
+
+    @Transactional
+    @Override
+    public void useCoupon(String couponUuid, String memberUuid, LocalDateTime usedAt) {
+        memberCouponRepository.updateMemberStateToUsed(couponUuid, memberUuid, usedAt);
     }
 
     @Override

--- a/src/main/java/colorful/starbucks/coupon/application/MemberCouponServiceImpl.java
+++ b/src/main/java/colorful/starbucks/coupon/application/MemberCouponServiceImpl.java
@@ -9,11 +9,9 @@ import colorful.starbucks.coupon.dto.request.MemberCouponRequestDto;
 import colorful.starbucks.coupon.dto.response.MemberCouponResponseDto;
 import colorful.starbucks.coupon.infrastructure.MemberCouponRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)

--- a/src/main/java/colorful/starbucks/coupon/domain/Coupon.java
+++ b/src/main/java/colorful/starbucks/coupon/domain/Coupon.java
@@ -1,8 +1,6 @@
 package colorful.starbucks.coupon.domain;
 
 import colorful.starbucks.common.entity.BaseEntity;
-import colorful.starbucks.common.exception.BaseException;
-import colorful.starbucks.common.response.ResponseStatus;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -98,17 +96,5 @@ public class Coupon extends BaseEntity {
         this.currentIssuanceCount = currentIssuanceCount;
         this.startAt = startAt;
         this.expiredAt = expiredAt;
-    }
-
-    public void issue() {
-        if (canIssue()) {
-            currentIssuanceCount++;
-        } else {
-            throw new BaseException(ResponseStatus.EXCEED_MAX_COUPON_COUNT);
-        }
-    }
-
-    private boolean canIssue() {
-        return currentIssuanceCount < maxIssuanceLimit;
     }
 }

--- a/src/main/java/colorful/starbucks/coupon/infrastructure/CouponRepository.java
+++ b/src/main/java/colorful/starbucks/coupon/infrastructure/CouponRepository.java
@@ -2,10 +2,16 @@ package colorful.starbucks.coupon.infrastructure;
 
 import colorful.starbucks.coupon.domain.Coupon;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
 
     Optional<Coupon> findByCouponUuid(String couponUuid);
+
+    @Modifying
+    @Query("UPDATE Coupon c SET c.currentIssuanceCount = :newIssuanceCount WHERE c.couponUuid = :couponUuid")
+    void updateCouponIssuanceCount(String couponUuid, int newIssuanceCount);
 }

--- a/src/main/java/colorful/starbucks/coupon/infrastructure/MemberCouponRepository.java
+++ b/src/main/java/colorful/starbucks/coupon/infrastructure/MemberCouponRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long>, MemberCouponRepositoryCustom {
     Optional<MemberCoupon> findByMemberUuidAndCouponUuid(String memberUuid, String couponUuid);
+
+    boolean existsByMemberUuidAndCouponUuid(String memberUuid, String couponUuid);
 }

--- a/src/main/java/colorful/starbucks/coupon/infrastructure/MemberCouponRepository.java
+++ b/src/main/java/colorful/starbucks/coupon/infrastructure/MemberCouponRepository.java
@@ -2,11 +2,22 @@ package colorful.starbucks.coupon.infrastructure;
 
 import colorful.starbucks.coupon.domain.MemberCoupon;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long>, MemberCouponRepositoryCustom {
     Optional<MemberCoupon> findByMemberUuidAndCouponUuid(String memberUuid, String couponUuid);
 
     boolean existsByMemberUuidAndCouponUuid(String memberUuid, String couponUuid);
+
+    @Modifying
+    @Query(
+            "UPDATE MemberCoupon mc " +
+                    "SET mc.isUsed = true, mc.usedAt = :usedAt " +
+                    "WHERE mc.couponUuid = :couponUuid AND mc.memberUuid = :memberUuid"
+    )
+    void updateMemberStateToUsed(String couponUuid, String memberUuid, LocalDateTime usedAt);
 }

--- a/src/main/java/colorful/starbucks/product/application/InterestProductServiceImpl.java
+++ b/src/main/java/colorful/starbucks/product/application/InterestProductServiceImpl.java
@@ -12,8 +12,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class InterestProductServiceImpl implements InterestProductService {
 
     private final InterestProductRepository interestProductRepository;

--- a/src/main/java/colorful/starbucks/product/application/ProductDetailServiceImpl.java
+++ b/src/main/java/colorful/starbucks/product/application/ProductDetailServiceImpl.java
@@ -19,8 +19,8 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ProductDetailServiceImpl implements ProductDetailService {
 
     private final ProductDetailRepository productDetailRepository;

--- a/src/main/java/colorful/starbucks/product/application/ProductServiceImpl.java
+++ b/src/main/java/colorful/starbucks/product/application/ProductServiceImpl.java
@@ -18,8 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ProductServiceImpl implements ProductService {
 
     private final ProductRepository productRepository;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #137 

## 📝작업 내용

쿠폰 도메인을 순수하게 가져가기 위해 더티체킹으로 상태를 변경하던 로직을 서비스 단에서 처리했습니다.
분산락을 적용하면서 트랜잭션이 먼저 적용되고 락을 획득하는 순서에서 락 획득을 먼저 시도하고 트랜잭션을 적용하도록 Order를 설정했습니다.

기존 로직은 트랜잭션이 우선 적용되므로 connection을 맺고 커넥션풀의 모든 자원을 사용해서 분산락 내부 로직이 실행되지 못하는 데드락 상황이 발생했습니다. 또한, 트랜잭션이 먼저 적용되고 락을 획득하면 다른 스레드에서 커밋이 적용되기 전에 락을 획득할 수 있어서 순서를 변경했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
